### PR TITLE
Ensure pipeline receives RGB images

### DIFF
--- a/age_estimator.py
+++ b/age_estimator.py
@@ -10,6 +10,8 @@ from facenet_pytorch import MTCNN
 from transformers import pipeline
 from pytube import YouTube
 
+# The age estimation pipeline expects images in RGB format. Some frames may be
+# grayscale, so we convert them before inference when needed.
 # setting device for torch computations
 device = 0 if torch.cuda.is_available() else -1
 
@@ -82,6 +84,10 @@ def predict_age(face_img):
     """
     face_rgb = cv2.cvtColor(face_img, cv2.COLOR_BGR2RGB)
     pil_img = Image.fromarray(face_rgb)
+    # Some frames may be stored in grayscale. The pipeline expects RGB
+    # input, so convert if needed.
+    if pil_img.mode == "L":
+        pil_img = pil_img.convert("RGB")
 
     # get predictions from the pipeline
     predictions = age_pipe(pil_img)

--- a/evaluate_age_model.py
+++ b/evaluate_age_model.py
@@ -16,6 +16,9 @@ from PIL import Image
 from transformers import pipeline
 import torch
 
+# The evaluation pipeline requires RGB images. Some dataset files might be in
+# grayscale, so we convert them before inference when detected.
+
 DATA_DIR = Path("wiki_crop/wiki_crop")
 MODEL_DIR = Path("local_model")
 
@@ -58,7 +61,12 @@ def evaluate_dataset() -> dict[str, float]:
 
     for img_path in image_paths:
         gt_age = parse_age_from_filename(img_path)
-        prediction = predictor(Image.open(img_path))[0]["label"]
+        img = Image.open(img_path)
+        # Images in the dataset might be grayscale; convert to RGB for the
+        # predictor if needed.
+        if img.mode == "L":
+            img = img.convert("RGB")
+        prediction = predictor(img)[0]["label"]
         pred_age = parse_predicted_age(prediction)
         y_true.append(gt_age)
         y_pred.append(pred_age)


### PR DESCRIPTION
## Summary
- document that the age estimator expects RGB input
- convert grayscale frames to RGB in `predict_age`
- handle grayscale dataset images in `evaluate_age_model`

## Testing
- `python -m py_compile age_estimator.py evaluate_age_model.py`

------
https://chatgpt.com/codex/tasks/task_e_685079d908788333b34428d706078530